### PR TITLE
136 [deployment] Add Scratchy in docker compose environment.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,3 +10,11 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: example
     volumes:
       - ./data:/data/db
+
+  scratchy:
+    image: scratchy-server:latest
+    ports:
+      - "5000:5000"
+    links:
+      - "mongodb"
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,4 +17,6 @@ services:
       - "5000:5000"
     links:
       - "mongodb"
+    volumes:
+      - ./etc/scratchy/config.json:/app/config.json
 

--- a/docker/etc/scratchy/config.json
+++ b/docker/etc/scratchy/config.json
@@ -1,0 +1,10 @@
+{
+    "MONGODB_SETTINGS": {
+        "db": "scratchy",
+        "username": "root",
+        "password": "example",
+        "host": "mongodb",
+        "port": 27017,
+        "authentication_source": "admin"
+    }
+}


### PR DESCRIPTION
Add scratchy in docker-compose using the scratchy-server docker image.
Expose port.
Link to mongodb.
