### PR TITLE
125 [back] [metrics] add metrics to scratchy.

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -32,6 +32,8 @@ paho-mqtt==1.5.1
 pathspec==0.8.1
 pbr==5.6.0
 pluggy==0.13.1
+prometheus-client==0.11.0
+prometheus-flask-exporter==0.18.2
 py==1.10.0
 pycodestyle==2.7.0
 pyflakes==2.3.1
@@ -45,6 +47,7 @@ python-dateutil==2.8.1
 pytz==2020.5
 PyYAML==5.4.1
 requests==2.25.1
+six==1.16.0
 stevedore==3.3.0
 tavern==1.14.2
 template-remover==0.1.9

--- a/server/scratchy_server/__main__.py
+++ b/server/scratchy_server/__main__.py
@@ -9,6 +9,7 @@ from flask.cli import cli
 def main():
     os.environ['FLASK_APP'] = 'scratchy_server.app'
     os.environ['FLASK_ENV'] = 'development'
+    os.environ['DEBUG_METRICS'] = "True" # Needed for prometheus to work. See : https://stackoverflow.com/a/66650309 
     sys.exit(cli.main(args=['run', '--host=0.0.0.0'], prog_name="python -m flask"))
 
 

--- a/server/scratchy_server/app.py
+++ b/server/scratchy_server/app.py
@@ -6,6 +6,8 @@ from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 import logging
 
+from prometheus_flask_exporter import PrometheusMetrics
+
 from scratchy_server import db_scratchy
 from scratchy_server.resources.roomres import RoomRes, AllRoomRes
 from scratchy_server.resources.userres import UserRes, AllUserRes
@@ -38,6 +40,12 @@ app.config.update({
 docs = FlaskApiSpec(app)
 db_scratchy.init_app(app)
 api = Api(app)
+
+## Add Metrics for Scratchy
+metrics = PrometheusMetrics(app)
+# metrics.register_endpoint('/metrics')
+# static information as metric
+metrics.info('app_info', 'Application info', version='2.0.0')
 
 ressource = (
     {"name": "RoomRes", "ressource": RoomRes, "url": "/api/room/<string:roomId>"},


### PR DESCRIPTION
installation:
$ pip install prometheus-flask-exporter
or
$ pip install -r requirements.txt

get metrics:
* start scratchy
* get metrics
$ curl http://localhost:5000/metrics

Should output something like that:
```
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 445.0
python_gc_objects_collected_total{generation="1"} 466.0
python_gc_objects_collected_total{generation="2"} 0.0
# HELP python_gc_objects_uncollectable_total Uncollectable object found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 86.0
python_gc_collections_total{generation="1"} 7.0
python_gc_collections_total{generation="2"} 0.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="8",patchlevel="10",version="3.8.10"} 1.0
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1.22003456e+08
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 3.1944704e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.62713218493e+09
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0.19
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 6.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1024.0
# HELP flask_exporter_info Information about the Prometheus Flask exporter
# TYPE flask_exporter_info gauge
flask_exporter_info{version="0.18.2"} 1.0
...
```

But it does not work as expected !
